### PR TITLE
Add function to properly calculate font-clamp preferred value

### DIFF
--- a/wp-content/themes/missilethreat/assets/_scss/abstracts/_functions.scss
+++ b/wp-content/themes/missilethreat/assets/_scss/abstracts/_functions.scss
@@ -13,7 +13,7 @@ $browser-context: 16px;
   }
 
   $rem-size: $size / $browser-context;
-  @return #{$rem-size}rem;
+  @return $rem-size * 1rem;
 }
 
 @function is-number($value) {
@@ -22,4 +22,22 @@ $browser-context: 16px;
 
 @function is-px($value) {
   @return is-number($value) and index('px', unit($value)) != null;
+}
+
+// Calculates the slope based off the min/max font size and min/max widths.
+@function calc-slope($min-font-size, $max-font-size) {
+  $font-size-diff: $max-font-size - $min-font-size;
+
+  $result: ($font-size-diff / $container-width-diff);
+
+  @return $result;
+}
+
+// Returns the preferred value for the font-clamp mixin based on the min/max font sizes.
+@function calc-preferred-font-value($min-font-size, $max-font-size) {
+  $slope: calc-slope($min-font-size, $max-font-size);
+
+  $intersection: -($container-min-width) * $slope + $min-font-size;
+
+  @return ($intersection, ($slope * 100vw));
 }

--- a/wp-content/themes/missilethreat/assets/_scss/abstracts/_mixins.scss
+++ b/wp-content/themes/missilethreat/assets/_scss/abstracts/_mixins.scss
@@ -1,6 +1,7 @@
 @use 'variables' as *;
 @use 'functions' as *;
 @use 'sass:map';
+@use 'sass:list';
 
 /*=================================
 =            Mixins            =
@@ -48,16 +49,30 @@
   font-size: rem($size);
 }
 
-// Font scales in size with the smallest media query size allowed to the ideal and largest.  
+// Font scales in size with the smallest media query size allowed to the ideal and largest.
 // Parameters are the minimum and maximum font size(px) as dictated in Figma.
+// Taken from: https://css-tricks.com/linearly-scale-font-size-with-css-clamp-based-on-the-viewport/
 @mixin font-clamp($min, $max) {
-  $min-rem: rem($min);
-  $half-min-rem: calc(#{$min-rem} / 2);
-  font-size: $min; //Fallback in px
-  font-size: $min-rem;
-  font-size: clamp(#{$min-rem}, calc(#{$half-min-rem} + 0.666vw), #{rem($max)});
-}
+  $min-font-size: rem($min);
+  $max-font-size: rem($max);
 
+  $preferred-value: calc-preferred-font-value($min-font-size, $max-font-size);
+
+  $preferred-font-size: list.nth($preferred-value, 1);
+
+  $preferred-vw: list.nth($preferred-value, 2);
+
+  font-size: $min; //Fallback in px
+  font-size: $min-font-size;
+
+  /* stylelint-disable */
+  font-size: clamp(
+    #{$min-font-size},
+    calc(#{$preferred-font-size} + #{$preferred-vw}),
+    #{$max-font-size}
+  );
+  /* stylelint-enable */
+}
 @mixin vw100() {
   width: 100vw; // Fallback for old browsers
   width: calc(100vw - var(--scrollbar));

--- a/wp-content/themes/missilethreat/assets/_scss/abstracts/_variables.scss
+++ b/wp-content/themes/missilethreat/assets/_scss/abstracts/_variables.scss
@@ -52,6 +52,11 @@ $breakpoints: (
   'xxlarge': 87.5em,
 );
 
+// Used to calculate font size in font-clamp mixin.
+$container-min-width: 30rem;
+$container-max-width: 87.5rem;
+$container-width-diff: 57.5rem; // Difference in rems between small & large breakpoints
+
 $size__container-max-width: 1400px;
 $size__content-max-width: 680px;
 $size__content-wide-max-width: 1120px;


### PR DESCRIPTION
This PR fixes the `font-clamp()` mixin and properly calculates the preferred value by applying the math used in [this article](https://css-tricks.com/linearly-scale-font-size-with-css-clamp-based-on-the-viewport/). To do this, I also modified the existing `rem()` function so it is returning a number with a unit and not a string.