### PR TITLE
Defense sys bugs

### DIFF
--- a/wp-content/themes/missilethreat/assets/_scss/components/_system-elements.scss
+++ b/wp-content/themes/missilethreat/assets/_scss/components/_system-elements.scss
@@ -9,7 +9,7 @@
 
   @include breakpoint('medium') {
     float: unset !important;
-    max-width: rem(400px);
+    max-width: rem(300px);
     margin-right: auto !important;
     margin-left: auto !important;
   }

--- a/wp-content/themes/missilethreat/inc/cpts/defense-systems.php
+++ b/wp-content/themes/missilethreat/inc/cpts/defense-systems.php
@@ -19,6 +19,7 @@ function missiledefense_cpt_defsys() {
             'supports' => array( 'title', 'editor', 'excerpt', 'publicize', 'thumbnail', 'author' ),
 			'public' => true,
 			'has_archive' => true,
+            'show_in_rest' => true,
 	    )
   	);
 }

--- a/wp-content/themes/missilethreat/template-parts/breadcrumbs.php
+++ b/wp-content/themes/missilethreat/template-parts/breadcrumbs.php
@@ -24,7 +24,7 @@ if( $post_type === 'defsys') {
   ?>
 <ul class="breadcrumbs breadcrumbs--light" role="list">
   <li><a href="/defsys">Defense Systems</a></li>
-  <li>System: <span class="text--semibold"><?php the_title(); ?></span></li>
+  <li><span class="text--semibold"><?php the_title(); ?></span></li>
 </ul><br style="clear:left;" />
 
   <?php


### PR DESCRIPTION
Per request from the program
- Removed "System:" from the breadcrumbs on the system pages.
- Added support for Gutenberg on the defense systems CPT.
- Decreased size of System Elements list on system pages.