### PR TITLE
Enqueue post stylesheet in actors scss

### DIFF
--- a/wp-content/themes/missilethreat/assets/_scss/pages/actors.scss
+++ b/wp-content/themes/missilethreat/assets/_scss/pages/actors.scss
@@ -1,4 +1,5 @@
 @use '../abstracts' as *;
+@use 'post.scss';
 
 .single-actors {
   /* stylelint-disable-next-line */

--- a/wp-content/themes/missilethreat/functions.php
+++ b/wp-content/themes/missilethreat/functions.php
@@ -202,7 +202,7 @@ function missilethreat_register_styles() {
 		wp_enqueue_style( 'missilethreat-style-single', get_stylesheet_directory_uri() . '/assets/css/pages/single.min.css', array(), $theme_version );
 	}
 
-	if ( is_singular( array( 'post', 'defsys', 'missile', 'systems', 'actors' ) ) ) {
+	if ( is_singular( array( 'post', 'defsys', 'missile', 'systems' ) ) ) {
 		wp_enqueue_style( 'missilethreat-style-post', get_stylesheet_directory_uri() . '/assets/css/pages/post.min.css', array(), $theme_version );
 	}
 


### PR DESCRIPTION
Stop enqueuing post stylesheet for actors in functions file and pull it in in actors.scss instead.